### PR TITLE
Add code owners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DavidMStraub


### PR DESCRIPTION
It auto-assigns David as reviewer of all PRs and
documents who owns this code, e.g. for people
from Proxima that might find the repo and have
no context.