### PR TITLE
Simplify pytree registration

### DIFF
--- a/src/raytrax/equilibrium/interpolate.py
+++ b/src/raytrax/equilibrium/interpolate.py
@@ -9,6 +9,7 @@ to cylindrical coordinates ($r$, $\phi$, $z$).
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -32,6 +33,7 @@ from .fourier import (
 )
 
 
+@jax.tree_util.register_dataclass
 @dataclass
 class MagneticConfiguration(SafetensorsMixin):
     r"""Magnetic configuration and geometry on a cylindrical grid.
@@ -50,10 +52,10 @@ class MagneticConfiguration(SafetensorsMixin):
     rho: jt.Float[jax.Array, " npoints"]
     """The normalized effective minor radius at each point on the interpolation grid."""
 
-    nfp: int
+    nfp: int = dataclass_field(metadata={"static": True})
     """Number of field periods (toroidal periodicity)."""
 
-    is_stellarator_symmetric: bool
+    is_stellarator_symmetric: bool = dataclass_field(metadata={"static": True})
     """Whether the configuration has stellarator symmetry."""
 
     rho_1d: jt.Float[jax.Array, " nrho_1d"]
@@ -62,7 +64,7 @@ class MagneticConfiguration(SafetensorsMixin):
     dvolume_drho: jt.Float[jax.Array, " nrho_1d"]
     r"""Volume derivative $dV/d\rho$ on the 1D radial grid."""
 
-    is_axisymmetric: bool = False
+    is_axisymmetric: bool = dataclass_field(default=False, metadata={"static": True})
     """Whether the configuration is axisymmetric (tokamak) or 3D (stellarator)."""
 
     @classmethod

--- a/src/raytrax/tracer/buffers.py
+++ b/src/raytrax/tracer/buffers.py
@@ -1,12 +1,14 @@
 """JAX pytree types for the ODE solver: Interpolators (field/profile inputs) and TraceBuffers (padded output arrays)."""
 
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 
 import interpax
 import jax
 import jaxtyping as jt
 
 
+@jax.tree_util.register_dataclass
 @dataclass(frozen=True)
 class Interpolators:
     """Bundle of interpolation functions for ray tracing.
@@ -27,26 +29,11 @@ class Interpolators:
     electron_temperature: interpax.Interpolator1D
     """Interpolator for Te(rho)."""
 
-    is_axisymmetric: bool = False
+    is_axisymmetric: bool = dataclass_field(default=False, metadata={"static": True})
     """Whether the equilibrium is axisymmetric (tokamak). Stored in pytree aux_data."""
 
 
-jax.tree_util.register_pytree_node(
-    Interpolators,
-    lambda i: (
-        (i.magnetic_field, i.rho, i.electron_density, i.electron_temperature),
-        (i.is_axisymmetric,),
-    ),
-    lambda aux, children: Interpolators(
-        magnetic_field=children[0],
-        rho=children[1],
-        electron_density=children[2],
-        electron_temperature=children[3],
-        is_axisymmetric=aux[0],
-    ),
-)
-
-
+@jax.tree_util.register_dataclass
 @dataclass(frozen=True)
 class TraceBuffers:
     """Raw output from the JIT-compiled trace, before trimming padded buffers.
@@ -64,33 +51,3 @@ class TraceBuffers:
     absorption_coefficient: jt.Float[jax.Array, " nsteps"]
     linear_power_density: jt.Float[jax.Array, " nsteps"]
     volumetric_power_density: jt.Float[jax.Array, " nsteps"]
-
-
-jax.tree_util.register_pytree_node(
-    TraceBuffers,
-    lambda r: (
-        (
-            r.arc_length,
-            r.ode_state,
-            r.magnetic_field,
-            r.normalized_effective_radius,
-            r.electron_density,
-            r.electron_temperature,
-            r.absorption_coefficient,
-            r.linear_power_density,
-            r.volumetric_power_density,
-        ),
-        None,
-    ),
-    lambda _, children: TraceBuffers(
-        arc_length=children[0],
-        ode_state=children[1],
-        magnetic_field=children[2],
-        normalized_effective_radius=children[3],
-        electron_density=children[4],
-        electron_temperature=children[5],
-        absorption_coefficient=children[6],
-        linear_power_density=children[7],
-        volumetric_power_density=children[8],
-    ),
-)

--- a/src/raytrax/tracer/ray.py
+++ b/src/raytrax/tracer/ray.py
@@ -1,50 +1,24 @@
 """ODE state types: RaySetting (frequency, mode) and RayState (position, refractive index, optical depth)."""
 
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from typing import Literal
 
 import jax
 import jaxtyping as jt
 
 
+@jax.tree_util.register_dataclass
 @dataclass(frozen=True)
 class RaySetting:
     frequency: jt.Float[jax.Array, ""]
-    mode: Literal["X", "O"]
+    mode: Literal["X", "O"] = dataclass_field(metadata={"static": True})
 
 
+@jax.tree_util.register_dataclass
 @dataclass(frozen=True)
 class RayState:
     position: jt.Float[jax.Array, "3"]
     refractive_index: jt.Float[jax.Array, "3"]
     optical_depth: jt.Float[jax.Array, ""]
     arc_length: jt.Float[jax.Array, ""]
-
-
-jax.tree_util.register_pytree_node(
-    RayState,
-    lambda rs: (
-        (
-            rs.position,
-            rs.refractive_index,
-            rs.optical_depth,
-            rs.arc_length,
-        ),
-        None,
-    ),
-    lambda _, children: RayState(
-        position=children[0],
-        refractive_index=children[1],
-        optical_depth=children[2],
-        arc_length=children[3],
-    ),
-)
-
-jax.tree_util.register_pytree_node(
-    RaySetting,
-    lambda rs: ((rs.frequency,), (rs.mode,)),
-    lambda aux_data, children: RaySetting(
-        frequency=children[0],
-        mode=aux_data[0],  # type: ignore
-    ),
-)

--- a/src/raytrax/types.py
+++ b/src/raytrax/types.py
@@ -1,6 +1,7 @@
 """Public data types for the raytrax API: beam inputs, trace outputs, and shared utilities."""
 
 from dataclasses import dataclass, fields
+from dataclasses import field as dataclass_field
 from typing import Any, Literal, TypeVar
 
 import jax
@@ -75,6 +76,7 @@ class SafetensorsMixin:
         return cls(**field_values)
 
 
+@jax.tree_util.register_dataclass
 @dataclass
 class Beam:
     """Beam parameter inputs for tracing."""
@@ -88,13 +90,14 @@ class Beam:
     frequency: jt.Float[jax.Array, ""]
     """The frequency of the beam in Hz (not GHz!)."""
 
-    mode: Literal["X", "O"]
+    mode: Literal["X", "O"] = dataclass_field(metadata={"static": True})
     """The polarization mode of the beam, either `"X"` for extraordinary or `"O"` for ordinary mode."""
 
     power: float
     """The initial power of the beam in W (not MW!)."""
 
 
+@jax.tree_util.register_dataclass
 @dataclass
 class BeamProfile:
     """Beam profile in real space resulting from tracing."""
@@ -130,6 +133,7 @@ class BeamProfile:
     """The linear power density along the beam."""
 
 
+@jax.tree_util.register_dataclass
 @dataclass
 class RadialProfile:
     """Beam profile in radial coordinates."""
@@ -141,6 +145,7 @@ class RadialProfile:
     """The volumetric power density in W/m³."""
 
 
+@jax.tree_util.register_dataclass
 @dataclass
 class TraceResult:
     """The result of a ray tracing calculation."""
@@ -167,6 +172,7 @@ class TraceResult:
     r"""Flux-surface-volume-weighted standard deviation of $\rho$ for power deposition."""
 
 
+@jax.tree_util.register_dataclass
 @dataclass(frozen=True)
 class TracerSettings:
     """Settings for the ray tracing ODE solver.
@@ -191,26 +197,7 @@ class TracerSettings:
     """Maximum arc length to integrate in metres before the solver gives up."""
 
 
-jax.tree_util.register_pytree_node(
-    TracerSettings,
-    lambda s: (
-        (
-            s.relative_tolerance,
-            s.absolute_tolerance,
-            s.max_step_size,
-            s.max_arc_length,
-        ),
-        None,
-    ),
-    lambda _, children: TracerSettings(
-        relative_tolerance=children[0],
-        absolute_tolerance=children[1],
-        max_step_size=children[2],
-        max_arc_length=children[3],
-    ),
-)
-
-
+@jax.tree_util.register_dataclass
 @dataclass
 class RadialProfiles:
     r"""Radial profiles of electron density and temperature.


### PR DESCRIPTION
There's a utility in JAX versions since 0.4.36 specifically for registering dataclasses as pytrees
https://docs.jax.dev/en/latest/_autosummary/jax.tree_util.register_dataclass.html

This is arguably a bit more readable and less error prone than `register_pytree_node` and indexing tuples 