### PR TITLE
Regression test for jax initialization

### DIFF
--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -24,6 +24,7 @@ if initialized:
     result = subprocess.run(
         [sys.executable, "-c", script],
         capture_output=True,
+        timeout=120,
         text=True,
     )
     assert result.returncode == 0, (


### PR DESCRIPTION
Similar regressions have happened in e.g. `optimistix` https://github.com/patrick-kidger/optimistix/pull/186 and internally, so this test both guards against regressions in dependencies and makes sure we don't accidentally introduce this problem ourselves.

Note that there is no such issue in `raytrax` as of now (good job!), this is just me being careful.