### PR TITLE
Increase default values for r-z interpolation grid

### DIFF
--- a/src/raytrax/equilibrium/interpolate.py
+++ b/src/raytrax/equilibrium/interpolate.py
@@ -49,8 +49,8 @@ class CylindricalGridResolution:
         n_rho_profile: Number of radial points for the 1-D $dV/d\\rho$ profile.
     """
 
-    n_r: int = 45
-    n_z: int = 55
+    n_r: int = 95
+    n_z: int = 105
     n_phi: int = 50
     n_rho_profile: int = 200
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -21,9 +21,9 @@ def test_from_vmec_wout_w7x(w7x_wout):
     # Check the shapes match
     # The actual shape is (n_r, n_phi, n_z, 3) for rphiz and magnetic_field
     # and (n_r, n_phi, n_z) for rho
-    assert interpolator.rphiz.shape == (45, 50, 55, 3)
-    assert interpolator.magnetic_field.shape == (45, 50, 55, 3)
-    assert interpolator.rho.shape == (45, 50, 55)
+    assert interpolator.rphiz.shape == (95, 50, 105, 3)
+    assert interpolator.magnetic_field.shape == (95, 50, 105, 3)
+    assert interpolator.rho.shape == (95, 50, 105)
 
     # Check that non-NaN rho values are non-negative
     # Note: rho > 1 is expected for points outside the LCMS (in the vacuum region)


### PR DESCRIPTION
Increasing the default values of `n_r` and `n_z` as this comes at essentially zero runtime cost (linear interpolation does not degreade with larger grid), only slightly larger up front mesh computation time (once per equilibrium).