### PR TITLE
Multiple fixes in absorption calculation

### DIFF
--- a/docs/theory/absorption.md
+++ b/docs/theory/absorption.md
@@ -65,13 +65,20 @@ where $P_0$ is the initial power of the ray.
 
 ## Weakly Relativistic Dielectric Tensor
 
-For the hermitian part of the dispersion tensor appearing in the denominator of the absorption coefficient,
-
-$$\boldsymbol{\mathsf{D}}^H = \boldsymbol{\varepsilon_r}^H - n^2 \boldsymbol{I} + \boldsymbol{n}\boldsymbol{n}$$
-
-raytrax follows Travis[^1] by using the weakly relativistic dielectric tensor taken from Krivenski and Orefice[^2].
+For the polarization eigenvector $\hat{\boldsymbol{e}}$ in the numerator of the absorption coefficient, raytrax follows Travis[^1] by using the weakly relativistic dielectric tensor from Krivenski and Orefice[^2].
 
 It is implemented in `raytrax.physics.dielectric_tensor.weakly_relativistic_dielectric_tensor`.
+
+
+## Power Flux Vector
+
+For the power flux vector in the denominator,
+
+$$\boldsymbol{F} = -\frac{1}{2}\frac{\partial}{\partial\boldsymbol{N}}\mathrm{Re}\!\left(\hat{\boldsymbol{e}}^* \cdot \boldsymbol{\mathsf{D}}^H \cdot \hat{\boldsymbol{e}}\right)$$
+
+raytrax evaluates this gradient using the cold dielectric tensor.
+
+It is implemented in `raytrax.physics.power_flux.cold_power_flux_vector_stix`.
 
 
 ## Fully Relativistic Dielectric Tensor

--- a/src/raytrax/api.py
+++ b/src/raytrax/api.py
@@ -140,7 +140,9 @@ def _run_trace(
     settings: TracerSettings,
 ) -> tuple[TraceBuffers, jax.Array]:
     """Build interpolators and run the JIT-compiled ODE solve."""
-    setting = RaySetting(frequency=beam.frequency, mode=beam.mode)
+    setting = RaySetting(
+        frequency=beam.frequency, mode=beam.mode, max_harmonic=beam.max_harmonic
+    )
     interpolators = Interpolators(
         magnetic_field=build_magnetic_field_interpolator(magnetic_configuration),
         rho=build_rho_interpolator(magnetic_configuration),

--- a/src/raytrax/physics/absorption.py
+++ b/src/raytrax/physics/absorption.py
@@ -23,6 +23,7 @@ def absorption_coefficient_conditional(
     electron_temperature_keV: ScalarFloat,
     frequency: ScalarFloat,
     mode: Literal["X", "O"],
+    max_harmonic: int = 2,
 ) -> ScalarFloat:
     """Compute the absorption coefficient if the density and temperature fulfill minimum
     requirements, otherwise return zero.
@@ -34,6 +35,10 @@ def absorption_coefficient_conditional(
         electron_temperature_keV: Electron temperature in keV.
         frequency: Frequency of the wave in Hz.
         mode: Polarization mode, either "X" for extraordinary or "O" for ordinary.
+        max_harmonic: Highest cyclotron harmonic to include in the absorption
+            calculation. Determines the KO tensor FLR order and the number of
+            resonance integrals evaluated. Must be a Python integer (compile-time
+            constant for JIT).
 
     Returns:
         Absorption coefficient alpha in m^-1.
@@ -55,6 +60,7 @@ def absorption_coefficient_conditional(
             electron_temperature_keV=safe_te,
             frequency=frequency,
             mode=mode,
+            max_harmonic=max_harmonic,
         ),
         lambda: 0.0,
     )
@@ -67,6 +73,7 @@ def absorption_coefficient(
     electron_temperature_keV: ScalarFloat,
     frequency: ScalarFloat,
     mode: Literal["X", "O"],
+    max_harmonic: int = 2,
 ) -> ScalarFloat:
     r"""Compute the absorption coefficient $\alpha$.
 
@@ -77,6 +84,9 @@ def absorption_coefficient(
         electron_temperature_keV: Electron temperature in keV.
         frequency: Frequency of the wave in Hz.
         mode: Polarization mode, either "X" for extraordinary or "O" for ordinary.
+        max_harmonic: Highest cyclotron harmonic to include. Determines the KO
+            tensor FLR order and the number of resonance integrals evaluated.
+            Must be a Python integer (compile-time constant for JIT).
 
     Returns:
         Absorption coefficient $\alpha$ in 1/m.
@@ -95,6 +105,9 @@ def absorption_coefficient(
     thermal_velocity = quantities.normalized_electron_thermal_velocity(
         electron_temperature_keV=electron_temperature_keV
     )
+    # The FLR expansion order must be at least as large as the resonant harmonic
+    # so that the polarization eigenvector captures the leading-order FLR correction
+    # at the resonance.  (max_s and max_k must be Python constants for JIT.)
     dielectric_tensor = dielectric_tensor_module.weakly_relativistic_dielectric_tensor(
         frequency=frequency,
         plasma_frequency=plasma_frequency,
@@ -102,8 +115,8 @@ def absorption_coefficient(
         thermal_velocity=thermal_velocity,
         refractive_index_para=refractive_index_para,
         refractive_index_perp=refractive_index_perp,
-        max_s=2,
-        max_k=1,
+        max_s=max_harmonic,
+        max_k=max_harmonic,
     )
     polarization_vector = polarization.polarization(
         dielectric_tensor=dielectric_tensor,
@@ -113,13 +126,12 @@ def absorption_coefficient(
         cyclotron_frequency=cyclotron_frequency,
         mode=mode,
     )
-    power_flux_vector = power_flux.power_flux_vector_stix(
+    power_flux_vector = power_flux.cold_power_flux_vector_stix(
         refractive_index_perp=refractive_index_perp,
         refractive_index_para=refractive_index_para,
         frequency=frequency,
         plasma_frequency=plasma_frequency,
         cyclotron_frequency=cyclotron_frequency,
-        thermal_velocity=thermal_velocity,
         mode=mode,
     )
     eAe = anti_hermitian_dielectric_form(
@@ -130,6 +142,7 @@ def absorption_coefficient(
         refractive_index_perp=refractive_index_perp,
         thermal_velocity=thermal_velocity,
         polarization_vector=polarization_vector,
+        max_harmonic=max_harmonic,
     )
     # Absorption coefficient: alpha = (omega/c) * eAe / |F|
     # where eAe = ê* · ε_r^A · ê is the anti-Hermitian dielectric form
@@ -158,6 +171,7 @@ def anti_hermitian_dielectric_form(
     refractive_index_perp: ScalarFloat,
     thermal_velocity: ScalarFloat,
     polarization_vector: jt.Complex[jax.Array, "3"],
+    max_harmonic: int = 2,
 ) -> ScalarFloat:
     r"""Compute $\hat{e}^* \cdot \boldsymbol{\varepsilon}_r^A \cdot \hat{e}$, the
     anti-Hermitian part of the relative dielectric tensor contracted with the
@@ -189,13 +203,13 @@ def anti_hermitian_dielectric_form(
         refractive_index_perp: Refractive index perpendicular to the magnetic field.
         thermal_velocity: Normalized electron thermal velocity (v_th / c).
         polarization_vector: Normalized polarization vector in Stix coordinates.
+        max_harmonic: Highest cyclotron harmonic to include in the sum.
 
     Returns:
         The scalar quadratic form :math:`\hat{e}^* \cdot \boldsymbol{\varepsilon}_r^A \cdot \hat{e}` (dimensionless).
     """  # noqa: E501
     resonance_integral = 0.0
-    # TODO extend to higher harmonics - currently only 1st and 2nd harmonic
-    for harmonic_index in range(1, 3):
+    for harmonic_index in range(1, max_harmonic + 1):
         resonance_integral += jax.lax.cond(
             # The resonance condition is given by
             # gamma = nY + n_para * u_para
@@ -262,10 +276,9 @@ def compute_resonance_integral(
         polarization_vector: Normalized polarization vector in Stix coordinates.
         thermal_velocity: Normalized electron thermal velocity (v_th / c).
     """  # noqa: E501
-    # Determine the integration bounds
-    # See above for the description of the resonance condition as a circle in
-    # the u_perp, u_para plane. This determines u_min and u_max as the left and right
-    # boundaries of the circle.
+    # Integration bounds from the resonance circle.  The conditions
+    # γ = nY + N_∥·u_∥ and γ² = 1 + u_∥² + u_⊥² define a circle in the
+    # (u_∥, u_⊥) plane; setting u_⊥=0 gives the endpoints u_min and u_max.
     nY = harmonic_index * cyclotron_frequency / frequency
     n_para = refractive_index_para
     denom = 1 - n_para**2
@@ -277,18 +290,25 @@ def compute_resonance_integral(
     delta_u = jnp.sqrt(jnp.maximum(1e-30, disc)) / jnp.maximum(jnp.abs(denom), 1e-10)
     delta_u = jnp.where(disc < 0, 0.0, delta_u)
     u_res = nY * n_para / denom
-    u_min = u_res - delta_u
-    u_max = u_res + delta_u
-
-    # No u_gamma_limit = (1-nY)/n_para enforcement: its gradient ~1/n_para²
-    # diverges catastrophically when n_para≈0.  The γ²-u²-1<0 guard inside
-    # resonance_integrand already zeros the integrand for any u with γ<1.
+    # Use u_cutoff = 7 * thermal_velocity (exp(-24.5) ≈ 2e-11 of distribution peak).
+    u_cutoff = 7.0 * thermal_velocity
 
     # Early return if resonance region doesn't intersect bulk of distribution.
-    # intersects with the bulk of the Maxwellian. Use u_cutoff = 5 * thermal_velocity
-    # (corresponding to exp(-12.5) ≈ 4e-6 of the distribution peak).
-    u_cutoff = 5.0 * thermal_velocity
-    resonance_in_bulk = jnp.minimum(jnp.abs(u_min), jnp.abs(u_max)) < u_cutoff
+    # Use the unclamped delta_u so that wide resonance circles (large delta_u)
+    # that straddle u_para = 0 are not mistakenly rejected after clamping.
+    u_min_raw = u_res - delta_u
+    u_max_raw = u_res + delta_u
+    resonance_in_bulk = jnp.minimum(jnp.abs(u_min_raw), jnp.abs(u_max_raw)) < u_cutoff
+
+    # Clamp the integration window to [-u_cutoff, +u_cutoff].  For N_∥ → 1
+    # the resonance circle diverges; zero the contribution since the
+    # quasi-longitudinal regime is outside ECH validity.
+    near_lightline = jnp.abs(denom) < 1e-4
+    u_min = jnp.where(near_lightline, 0.0, jnp.maximum(u_min_raw, -u_cutoff))
+    u_max = jnp.where(near_lightline, 0.0, jnp.minimum(u_max_raw, +u_cutoff))
+
+    # The u_gamma_limit = (1-nY)/N_∥ bound is not enforced explicitly; the
+    # γ²−u_∥²−1<0 guard in resonance_integrand zeros the integrand for γ<1.
 
     def compute_integral() -> ScalarFloat:
         # K2_scaled = kve(2, mu) depends only on thermal_velocity, which is
@@ -297,19 +317,9 @@ def compute_resonance_integral(
         mu = 2 / thermal_velocity**2
         K2_scaled = bessel.kve_jax(2, mu)
 
-        # Grid resolution for the trapezoidal rule.
-        # The integrand is peaked on the resonance curve with a 1/e-folding width
-        # in u_para of ~ 1 / (mu * n_para), where mu = m_e c^2 / T_e = 2 / vth^2.
-        # The integration range is set by the resonance circle geometry and scales
-        # as ~ sqrt(n_para^2 + nY^2 - 1) / (1 - n_para^2).  Requiring ~5 points
-        # per 1/e-folding gives N_min ~ 3 * mu * n_para^2 / (1 - n_para^2).
-        #
-        # N=1000 covers the physically relevant ECRH parameter space:
-        #   T >= 0.5 keV (mu <= 770),  n_para <= 0.50  ->  N_min <= 770   [safe]
-        #   T >= 0.1 keV (mu <= 3100), n_para <= 0.25  ->  N_min <= 640   [safe]
-        # At T < 0.5 keV and n_para > 0.3 the integrand is more narrowly peaked,
-        # but the absorption coefficient is also exponentially suppressed (sub-thermal
-        # resonance), so the absolute error on alpha remains negligible.
+        # 1000-point trapezoidal grid.  The integrand 1/e-width scales as
+        # 1/(μ·N_∥) with μ = 2/v_th²; 1000 points gives ≥5 points per
+        # 1/e-folding for T ≥ 0.5 keV and N_∥ ≤ 0.5.
         u_grid = jnp.linspace(u_min, u_max, 1000)
 
         # Compute the integrand values
@@ -409,7 +419,6 @@ def _resonance_integrand_full(
         parallel_momentum=parallel_momentum,
         polarization_vector=polarization_vector,
     )
-    # FIXME hard-coded Maxwellian for now
     df_dgamma = distribution_function.maxwell_juettner_distribution_dgamma_precomputed(
         lorentz_factor, thermal_velocity=thermal_velocity, K2_scaled=K2_scaled
     )
@@ -455,14 +464,14 @@ def quasilinear_diffusion_coefficient(
         jnp.maximum(1e-30, lorentz_factor**2 - parallel_momentum**2 - 1)
     )
 
-    # k_perp * rho_Larmor: k_perp = n_perp * omega / c,  rho_e = p_perp / (omega_c * m_0)
-    # => kperp_rho = N_perp * u_perp * freq / omega_ce  (non-negative: all factors are
-    #    non-negative because cyclotron_frequency is passed as a positive magnitude)
-    kperp_rho = (
+    # k_⊥ρ_L with the electron-helicity sign convention (negative).
+    # J_{-n}(-|z|) = J_n(|z|) for all n, whereas J_{-n}(+|z|) = (-1)^n J_n(|z|)
+    # differs by sign for odd harmonics; the minus ensures correct odd-n terms.
+    kperp_rho = -(
         refractive_index_perp * perpendicular_momentum * frequency / cyclotron_frequency
     )
 
-    # Safety check: avoid division by zero.
+    # Avoid division by zero in An1 = n·Jn/z.
     kperp_rho_threshold = 1e-10
     kperp_rho_safe = jnp.where(
         jnp.abs(kperp_rho) < kperp_rho_threshold,

--- a/src/raytrax/physics/dielectric_tensor.py
+++ b/src/raytrax/physics/dielectric_tensor.py
@@ -21,8 +21,9 @@ def cold_dielectric_tensor(
     Uses the Krivenski-Orefice (KO) electron-sign convention
     Y_e = ω_ce/ω = −|ω_ce|/ω < 0, matching the sign used internally by
     :func:`weakly_relativistic_dielectric_tensor`.  This gives ε[0,1] = +iD
-    (where D = (R−L)/2 > 0 for |Y| < 1 and positive densities), so both
-    functions produce identical off-diagonal signs in the T → 0 limit.
+    (where D = (R−L)/2; note that in this KO convention R = L_Stix, L = R_Stix,
+    so D = −D_Stix), ensuring both functions produce identical off-diagonal
+    signs in the T → 0 limit.
 
     Args:
         frequency: Wave frequency in Hz

--- a/src/raytrax/physics/dielectric_tensor.py
+++ b/src/raytrax/physics/dielectric_tensor.py
@@ -18,21 +18,28 @@ def cold_dielectric_tensor(
 ) -> jt.Complex[jax.Array, "3 3"]:
     """Returns the cold plasma dielectric tensor in Stix coordinates.
 
+    Uses the Krivenski-Orefice (KO) electron-sign convention
+    Y_e = ω_ce/ω = −|ω_ce|/ω < 0, matching the sign used internally by
+    :func:`weakly_relativistic_dielectric_tensor`.  This gives ε[0,1] = +iD
+    (where D = (R−L)/2 > 0 for |Y| < 1 and positive densities), so both
+    functions produce identical off-diagonal signs in the T → 0 limit.
+
     Args:
         frequency: Wave frequency in Hz
         plasma_frequency: Electron plasma frequency in Hz
-        cyclotron_frequency: Electron cyclotron frequency in Hz
+        cyclotron_frequency: Electron cyclotron frequency in Hz (positive magnitude;
+            the electron sign Y_e = −f_ce/f is applied internally)
 
     Returns:
         3x3 complex dielectric tensor in Stix coordinates
     """
     X = (plasma_frequency / frequency) ** 2
-    Y = cyclotron_frequency / frequency
+    Y = -cyclotron_frequency / frequency  # electron sign convention: Y_e < 0
 
-    R = 1 - X / (1 + Y)
-    L = 1 - X / (1 - Y)
-    S = 0.5 * (R + L)
-    D = 0.5 * (R - L)
+    R = 1 - X / (1 + Y)  # = L_Stix
+    L = 1 - X / (1 - Y)  # = R_Stix
+    S = 0.5 * (R + L)  # same as Stix S
+    D = 0.5 * (R - L)  # = -D_Stix
     P = 1 - X
 
     return jnp.array([[S, -1j * D, 0], [1j * D, S, 0], [0, 0, P]], dtype=jnp.complex128)
@@ -56,8 +63,9 @@ def weakly_relativistic_dielectric_tensor(
     Args:
         frequency: Wave frequency in Hz
         plasma_frequency: Electron plasma frequency in Hz
-        cyclotron_frequency: Electron cyclotron frequency in Hz (positive magnitude;
-            the sign convention for electrons is applied internally)
+        cyclotron_frequency: Electron cyclotron frequency in Hz (positive magnitude).
+            Internally the KO convention w_c = −2π·f_ce < 0 is applied for
+            electrons, matching the sign convention of :func:`cold_dielectric_tensor`.
         thermal_velocity: electron thermal velocity normalized to c
         refractive_index_para: Refractive index parallel to the magnetic field
         refractive_index_perp: Refractive index perpendicular to the magnetic field,

--- a/src/raytrax/physics/power_flux.py
+++ b/src/raytrax/physics/power_flux.py
@@ -146,3 +146,97 @@ def power_flux_vector_stix(
         max_k,
     )
     return -0.5 * grad_N
+
+
+def _cold_power_flux_hamiltonian_stix(
+    refractive_index: jt.Float[jax.Array, "3"],
+    frequency: ScalarFloat,
+    plasma_frequency: ScalarFloat,
+    cyclotron_frequency: ScalarFloat,
+    mode: Literal["X", "O"],
+) -> ScalarFloat:
+    r"""Cold-plasma power flux Hamiltonian :math:`H = \hat{e}^* \cdot D^H(\mathbf{N}) \cdot \hat{e}`.
+
+    Uses the cold dielectric tensor instead of the weakly-relativistic (KO) tensor,
+    avoiding the N-resonance singularities that arise when differentiating the warm
+    tensor near the electron cyclotron harmonic.  Thermal corrections to the group
+    velocity are O(v_th/c) ≲ 3 % and are neglected here.
+
+    Args:
+        refractive_index: Refractive index in Stix coordinates ``[N_perp, 0, N_para]``.
+        frequency: Wave frequency in Hz.
+        plasma_frequency: Electron plasma frequency in Hz.
+        cyclotron_frequency: Electron cyclotron frequency in Hz.
+        mode: Wave polarization mode, ``"X"`` for extraordinary or ``"O"`` for ordinary.
+
+    Returns:
+        Scalar real Hamiltonian value.
+    """
+    refractive_index_perp = refractive_index[0]
+    refractive_index_para = refractive_index[2]
+    eps = dielectric_tensor_module.cold_dielectric_tensor(
+        frequency=frequency,
+        plasma_frequency=plasma_frequency,
+        cyclotron_frequency=cyclotron_frequency,
+    )
+    polarization_vector = polarization_module.polarization(
+        dielectric_tensor=eps,
+        refractive_index_perp=refractive_index_perp,
+        refractive_index_para=refractive_index_para,
+        frequency=frequency,
+        cyclotron_frequency=cyclotron_frequency,
+        mode=mode,
+    )
+    dispersion_tensor = dispersion.dispersion_tensor_stix(
+        refractive_index_perp=refractive_index_perp,
+        refractive_index_para=refractive_index_para,
+        dielectric_tensor=eps,
+    )
+    dispersion_tensor_h = utils.hermitian_part(dispersion_tensor)
+    return jnp.real(
+        polarization_vector.conj() @ dispersion_tensor_h @ polarization_vector
+    )
+
+
+_cold_grad_hamiltonian = jax.grad(_cold_power_flux_hamiltonian_stix, argnums=0)
+
+
+def cold_power_flux_vector_stix(
+    refractive_index_perp: ScalarFloat,
+    refractive_index_para: ScalarFloat,
+    frequency: ScalarFloat,
+    plasma_frequency: ScalarFloat,
+    cyclotron_frequency: ScalarFloat,
+    mode: Literal["X", "O"],
+) -> jt.Float[jax.Array, "3"]:
+    r"""Compute the cold-plasma power flux vector in Stix coordinates.
+
+    Identical to :func:`power_flux_vector_stix` but uses the cold dielectric
+    tensor for the Hamiltonian gradient, avoiding the N-resonance singularities
+    that arise when differentiating the warm (KO) tensor near the ECR harmonic.
+    Thermal corrections to the group velocity are O(v_th/c) ≲ 3 % and are
+    neglected.
+
+    Args:
+        refractive_index_perp: Perpendicular refractive index.
+        refractive_index_para: Parallel refractive index.
+        frequency: Wave frequency in Hz.
+        plasma_frequency: Electron plasma frequency in Hz.
+        cyclotron_frequency: Electron cyclotron frequency in Hz.
+        mode: Wave polarization mode, ``"X"`` for extraordinary or ``"O"`` for ordinary.
+
+    Returns:
+        Power flux vector :math:`\mathbf{F} = -\tfrac{1}{2}\,\partial_\mathbf{N}(e^* D^H_\mathrm{cold} e)`.
+    """
+    refractive_index = jnp.array(
+        [refractive_index_perp, 0.0, refractive_index_para],
+        dtype=jnp.float64,
+    )
+    grad_N = _cold_grad_hamiltonian(
+        refractive_index,
+        frequency,
+        plasma_frequency,
+        cyclotron_frequency,
+        mode,
+    )
+    return -0.5 * grad_N

--- a/src/raytrax/tracer/ray.py
+++ b/src/raytrax/tracer/ray.py
@@ -13,6 +13,7 @@ import jaxtyping as jt
 class RaySetting:
     frequency: jt.Float[jax.Array, ""]
     mode: Literal["X", "O"] = dataclass_field(metadata={"static": True})
+    max_harmonic: int = dataclass_field(default=2, metadata={"static": True})
 
 
 @jax.tree_util.register_dataclass

--- a/src/raytrax/tracer/solver.py
+++ b/src/raytrax/tracer/solver.py
@@ -194,6 +194,7 @@ def _right_hand_side(
         electron_temperature_keV=te,
         frequency=setting.frequency,
         mode=setting.mode,
+        max_harmonic=setting.max_harmonic,
     )
 
     return jnp.concatenate([dr_ds, dn_ds, jnp.array([dtau_ds])])

--- a/src/raytrax/types.py
+++ b/src/raytrax/types.py
@@ -96,6 +96,11 @@ class Beam:
     power: float
     """The initial power of the beam in W (not MW!)."""
 
+    max_harmonic: int = dataclass_field(default=2, metadata={"static": True})
+    """Highest cyclotron harmonic included in the absorption calculation.
+    Controls both the KO-tensor FLR order and the number of resonance integrals
+    evaluated. Increase to 3 for 3rd-harmonic scenarios, etc. Defaults to 2."""
+
 
 @jax.tree_util.register_dataclass
 @dataclass

--- a/tests/physics/absorption_test.py
+++ b/tests/physics/absorption_test.py
@@ -5,9 +5,28 @@ import pytest
 from scipy.integrate import quad
 
 from raytrax.math import bessel
-from raytrax.physics import absorption, distribution_function
+from raytrax.physics import absorption, distribution_function, quantities
+from raytrax.physics.dielectric_tensor import (
+    cold_dielectric_tensor,
+    weakly_relativistic_dielectric_tensor,
+)
 
 jax.config.update("jax_enable_x64", True)
+
+
+# ---------------------------------------------------------------------------
+# Shared test parameters
+# ---------------------------------------------------------------------------
+
+# W7-X-like 2nd-harmonic X-mode scenario (B=2.52 T -> f_ce≈70.5 GHz, f=140 GHz)
+_FREQ = 140e9  # Hz
+_B_FIELD = jnp.array([0.0, 0.0, 2.52])  # T
+_N_PARA = 0.3
+_N_PERP = 0.7
+_N_VEC = jnp.array([_N_PERP, 0.0, _N_PARA])
+_NE = 0.3  # 1e20 m^-3
+_TE = 2.0  # keV
+_MODE = "X"
 
 
 def test_maxwell_juettner_normalization():
@@ -105,3 +124,294 @@ def test_absorption():
     assert not np.isnan(alpha), "Absorption coefficient is NaN"
     assert alpha >= 0, "Absorption coefficient should be non-negative"
     print(alpha)
+
+
+# ---------------------------------------------------------------------------
+# Tests for max_harmonic parameter
+# ---------------------------------------------------------------------------
+
+
+def test_absorption_coefficient_default_max_harmonic_is_two():
+    """Explicit max_harmonic=2 must give the same result as the default (2)."""
+    alpha_default = absorption.absorption_coefficient(
+        refractive_index=_N_VEC,
+        magnetic_field=_B_FIELD,
+        electron_density_1e20_per_m3=_NE,
+        electron_temperature_keV=_TE,
+        frequency=_FREQ,
+        mode=_MODE,
+    )
+    alpha_explicit = absorption.absorption_coefficient(
+        refractive_index=_N_VEC,
+        magnetic_field=_B_FIELD,
+        electron_density_1e20_per_m3=_NE,
+        electron_temperature_keV=_TE,
+        frequency=_FREQ,
+        mode=_MODE,
+        max_harmonic=2,
+    )
+    np.testing.assert_allclose(
+        float(alpha_default), float(alpha_explicit), rtol=0, atol=0
+    )
+
+
+def test_absorption_coefficient_max_harmonic_one():
+    """max_harmonic=1 must produce a finite, non-negative result at the fundamental."""
+    # At 1st harmonic resonance (B ~ 5 T for 140 GHz -> f_ce ≈ 140 GHz)
+    B_1st = jnp.array([0.0, 0.0, 5.0])
+    alpha = absorption.absorption_coefficient(
+        refractive_index=_N_VEC,
+        magnetic_field=B_1st,
+        electron_density_1e20_per_m3=_NE,
+        electron_temperature_keV=_TE,
+        frequency=_FREQ,
+        mode=_MODE,
+        max_harmonic=1,
+    )
+    assert np.isfinite(float(alpha)), "alpha must be finite for max_harmonic=1"
+    assert float(alpha) >= 0, "alpha must be non-negative"
+
+
+def test_absorption_coefficient_max_harmonic_three():
+    """max_harmonic=3 must produce a finite, non-negative result."""
+    alpha = absorption.absorption_coefficient(
+        refractive_index=_N_VEC,
+        magnetic_field=_B_FIELD,
+        electron_density_1e20_per_m3=_NE,
+        electron_temperature_keV=_TE,
+        frequency=_FREQ,
+        mode=_MODE,
+        max_harmonic=3,
+    )
+    assert np.isfinite(float(alpha)), "alpha must be finite for max_harmonic=3"
+    assert float(alpha) >= 0, "alpha must be non-negative"
+
+
+def test_absorption_coefficient_higher_harmonic_same_order_of_magnitude():
+    """max_harmonic=3 and max_harmonic=2 must give results of the same order of magnitude.
+
+    Note: alpha is *not* guaranteed to increase monotonically with max_harmonic,
+    because increasing max_harmonic also changes the KO dielectric tensor (and
+    thus the polarization eigenvector), which can slightly modify the result.
+    We only require both to be finite and within a factor of 2 of each other.
+    """
+    alpha2 = float(
+        absorption.absorption_coefficient(
+            refractive_index=_N_VEC,
+            magnetic_field=_B_FIELD,
+            electron_density_1e20_per_m3=_NE,
+            electron_temperature_keV=_TE,
+            frequency=_FREQ,
+            mode=_MODE,
+            max_harmonic=2,
+        )
+    )
+    alpha3 = float(
+        absorption.absorption_coefficient(
+            refractive_index=_N_VEC,
+            magnetic_field=_B_FIELD,
+            electron_density_1e20_per_m3=_NE,
+            electron_temperature_keV=_TE,
+            frequency=_FREQ,
+            mode=_MODE,
+            max_harmonic=3,
+        )
+    )
+    assert np.isfinite(alpha2) and np.isfinite(alpha3)
+    assert alpha2 > 0 and alpha3 > 0
+    ratio = alpha3 / alpha2
+    assert 0.5 <= ratio <= 2.0, (
+        f"max_harmonic=3 alpha ({alpha3:.4e}) should be within factor 2 of "
+        f"max_harmonic=2 alpha ({alpha2:.4e}), ratio={ratio:.3f}"
+    )
+
+
+def test_absorption_coefficient_conditional_zero_for_cold_plasma():
+    """absorption_coefficient_conditional must return 0 below temperature threshold."""
+    alpha = absorption.absorption_coefficient_conditional(
+        refractive_index=_N_VEC,
+        magnetic_field=_B_FIELD,
+        electron_density_1e20_per_m3=_NE,
+        electron_temperature_keV=0.001,  # below 0.01 keV threshold
+        frequency=_FREQ,
+        mode=_MODE,
+    )
+    np.testing.assert_allclose(float(alpha), 0.0, atol=0, rtol=0)
+
+
+def test_absorption_coefficient_conditional_zero_for_zero_density():
+    """absorption_coefficient_conditional must return 0 for zero density."""
+    alpha = absorption.absorption_coefficient_conditional(
+        refractive_index=_N_VEC,
+        magnetic_field=_B_FIELD,
+        electron_density_1e20_per_m3=0.0,
+        electron_temperature_keV=_TE,
+        frequency=_FREQ,
+        mode=_MODE,
+    )
+    np.testing.assert_allclose(float(alpha), 0.0, atol=0, rtol=0)
+
+
+def test_absorption_coefficient_conditional_matches_full_above_threshold():
+    """absorption_coefficient_conditional must equal absorption_coefficient above threshold."""
+    alpha_cond = float(
+        absorption.absorption_coefficient_conditional(
+            refractive_index=_N_VEC,
+            magnetic_field=_B_FIELD,
+            electron_density_1e20_per_m3=_NE,
+            electron_temperature_keV=_TE,
+            frequency=_FREQ,
+            mode=_MODE,
+        )
+    )
+    alpha_full = float(
+        absorption.absorption_coefficient(
+            refractive_index=_N_VEC,
+            magnetic_field=_B_FIELD,
+            electron_density_1e20_per_m3=_NE,
+            electron_temperature_keV=_TE,
+            frequency=_FREQ,
+            mode=_MODE,
+        )
+    )
+    np.testing.assert_allclose(alpha_cond, alpha_full, rtol=1e-12)
+
+
+def test_absorption_coefficient_conditional_respects_max_harmonic():
+    """max_harmonic is correctly threaded through absorption_coefficient_conditional."""
+    alpha2 = float(
+        absorption.absorption_coefficient_conditional(
+            refractive_index=_N_VEC,
+            magnetic_field=_B_FIELD,
+            electron_density_1e20_per_m3=_NE,
+            electron_temperature_keV=_TE,
+            frequency=_FREQ,
+            mode=_MODE,
+            max_harmonic=2,
+        )
+    )
+    alpha3 = float(
+        absorption.absorption_coefficient_conditional(
+            refractive_index=_N_VEC,
+            magnetic_field=_B_FIELD,
+            electron_density_1e20_per_m3=_NE,
+            electron_temperature_keV=_TE,
+            frequency=_FREQ,
+            mode=_MODE,
+            max_harmonic=3,
+        )
+    )
+    # The two values need not be equal (different harmonics), but both must be valid
+    assert np.isfinite(alpha2) and np.isfinite(alpha3)
+    # Check that conditional result for max_harmonic=2 matches the non-conditional version
+    alpha_full2 = float(
+        absorption.absorption_coefficient(
+            refractive_index=_N_VEC,
+            magnetic_field=_B_FIELD,
+            electron_density_1e20_per_m3=_NE,
+            electron_temperature_keV=_TE,
+            frequency=_FREQ,
+            mode=_MODE,
+            max_harmonic=2,
+        )
+    )
+    np.testing.assert_allclose(alpha2, alpha_full2, rtol=1e-12)
+
+
+def test_anti_hermitian_dielectric_form_positive():
+    """eAe must be strictly positive in an absorbing plasma."""
+    B_magnitude = float(jnp.linalg.norm(_B_FIELD))
+    cyclotron_freq = quantities.electron_cyclotron_frequency(B_magnitude)
+    plasma_freq = quantities.electron_plasma_frequency(_NE)
+    thermal_vel = quantities.normalized_electron_thermal_velocity(_TE)
+
+    # Build a simple polarization vector (unit vector in x – rough placeholder)
+    pol = jnp.array([1.0, 0.0, 0.0], dtype=jnp.complex128)
+
+    eAe = absorption.anti_hermitian_dielectric_form(
+        plasma_frequency=plasma_freq,
+        cyclotron_frequency=cyclotron_freq,
+        frequency=_FREQ,
+        refractive_index_para=_N_PARA,
+        refractive_index_perp=_N_PERP,
+        thermal_velocity=thermal_vel,
+        polarization_vector=pol,
+        max_harmonic=2,
+    )
+    assert np.isfinite(float(eAe)), "eAe must be finite"
+    assert float(eAe) >= 0, "eAe must be non-negative (absorbing plasma)"
+
+
+# ---------------------------------------------------------------------------
+# KO dielectric tensor cold-plasma limit
+# ---------------------------------------------------------------------------
+
+
+def test_ko_tensor_reduces_to_cold_in_low_temperature_limit():
+    """The KO warm tensor must converge element-wise to the cold tensor as T → 0.
+
+    Both functions use the KO electron-sign convention (Y_e = −f_ce/f < 0),
+    so all nine elements — including the off-diagonal ε[0,1] — must match
+    in both real and imaginary parts as T → 0.
+    """
+    frequency = 200e9
+    plasma_frequency = 50e9  # X_p = (f_p/f)^2 = 0.0625
+    cyclotron_frequency = 400e9  # Y = 2, far from every resonance
+    refractive_index_para = 0.5
+    refractive_index_perp = 0.3
+
+    eps_cold = cold_dielectric_tensor(
+        frequency=frequency,
+        plasma_frequency=plasma_frequency,
+        cyclotron_frequency=cyclotron_frequency,
+    )
+    eps_warm = weakly_relativistic_dielectric_tensor(
+        frequency=frequency,
+        plasma_frequency=plasma_frequency,
+        cyclotron_frequency=cyclotron_frequency,
+        thermal_velocity=quantities.normalized_electron_thermal_velocity(
+            electron_temperature_keV=1e-4
+        ),
+        refractive_index_para=refractive_index_para,
+        refractive_index_perp=refractive_index_perp,
+        max_s=2,
+        max_k=2,
+    )
+
+    # S and P diagonal elements
+    for i in range(3):
+        np.testing.assert_allclose(
+            float(eps_warm[i, i].real),
+            float(eps_cold[i, i].real),
+            rtol=1e-3,
+            err_msg=f"eps[{i},{i}].real should match cold",
+        )
+    # Anti-Hermitian diagonal must vanish (no absorption far from resonance)
+    for i in range(3):
+        np.testing.assert_allclose(
+            float(eps_warm[i, i].imag),
+            0.0,
+            atol=1e-6,
+            err_msg=f"eps[{i},{i}].imag should be ~0 far from resonance",
+        )
+    # Off-diagonal 1–3 and 2–3 blocks vanish
+    for i, j in [(0, 2), (1, 2), (2, 0), (2, 1)]:
+        np.testing.assert_allclose(
+            float(abs(eps_warm[i, j])),
+            0.0,
+            atol=1e-4,
+            err_msg=f"eps[{i},{j}] should vanish in cold limit",
+        )
+    # In-plane off-diagonal D: both sign AND magnitude must match
+    np.testing.assert_allclose(
+        float(eps_warm[0, 1].imag),
+        float(eps_cold[0, 1].imag),
+        rtol=1e-3,
+        err_msg="eps[0,1].imag (D element) must match cold value",
+    )
+    np.testing.assert_allclose(
+        float(eps_warm[1, 0].imag),
+        float(eps_cold[1, 0].imag),
+        rtol=1e-3,
+        err_msg="eps[1,0].imag (-D element) must match cold value",
+    )

--- a/tests/physics/dielectric_tensor_test.py
+++ b/tests/physics/dielectric_tensor_test.py
@@ -103,37 +103,133 @@ def test_weakly_relativistic_dielectric_tensor():
 
 
 def test_weakly_relativistic_converges_to_cold():
+    """The KO warm tensor must approach the cold tensor element-wise as T → 0.
+
+    Both functions use the KO electron-sign convention (Y_e = −|Y| < 0),
+    so all nine elements — including the off-diagonal imaginary parts — must
+    converge to the same values as T → 0.
+    """
+    # Use T = 1e-4 keV (v_th/c ≈ 2e-4) and max_s=2, max_k=2 to ensure adequate
+    # convergence far from resonance.  T = 1e-8 keV causes numerical overflow in
+    # the Shkarofsky recurrence at this extreme of mu = 2/v_th².
     frequency = 2.0e8  # Hz
     plasma_frequency = 1.0e8  # Hz
-    cyclotron_frequency = 5.0e8  # Hz
-    refractive_index_para = 1.2
-    electron_temperature_keV = 1e-8  # Very small temperature
+    cyclotron_frequency = 5.0e8  # Hz — Y = 2.5, far from every harmonic
+    refractive_index_para = 0.5
+    refractive_index_perp = 0.3
 
+    eps_cold = cold_dielectric_tensor(
+        frequency=frequency,
+        plasma_frequency=plasma_frequency,
+        cyclotron_frequency=cyclotron_frequency,
+    )
     eps_wr = weakly_relativistic_dielectric_tensor(
         frequency=frequency,
         plasma_frequency=plasma_frequency,
         cyclotron_frequency=cyclotron_frequency,
         thermal_velocity=quantities.normalized_electron_thermal_velocity(
-            electron_temperature_keV=electron_temperature_keV
+            electron_temperature_keV=1e-4
         ),
         refractive_index_para=refractive_index_para,
-        max_s=1,
-        max_k=1,
+        refractive_index_perp=refractive_index_perp,
+        max_s=2,
+        max_k=2,
     )
 
-    # these vanish in the cold plasma limit
-    np.testing.assert_allclose(eps_wr[0, 2], 0, rtol=0, atol=1e-8)
-    np.testing.assert_allclose(eps_wr[1, 2], 0, rtol=0, atol=1e-8)
-    np.testing.assert_allclose(eps_wr[2, 0], 0, rtol=0, atol=1e-8)
-    np.testing.assert_allclose(eps_wr[2, 1], 0, rtol=0, atol=1e-8)
+    # Off-diagonal 1–3 and 2–3 blocks vanish in the cold limit
+    for i, j in [(0, 2), (1, 2), (2, 0), (2, 1)]:
+        np.testing.assert_allclose(
+            eps_wr[i, j], 0, rtol=0, atol=1e-4, err_msg=f"eps_wr[{i},{j}] should vanish"
+        )
 
-    # these become equal in the cold plasma limit
-    np.testing.assert_allclose(eps_wr[0, 0], eps_wr[1, 1], rtol=0, atol=1e-8)
+    # Diagonal: S = (R+L)/2 and P = 1−X must match the cold values
+    np.testing.assert_allclose(
+        eps_wr[0, 0].real,
+        eps_cold[0, 0].real,
+        rtol=1e-3,
+        err_msg="S element (real part) should match cold",
+    )
+    np.testing.assert_allclose(
+        eps_wr[1, 1].real,
+        eps_cold[1, 1].real,
+        rtol=1e-3,
+        err_msg="S element (real part) should match cold",
+    )
+    np.testing.assert_allclose(
+        eps_wr[2, 2].real,
+        eps_cold[2, 2].real,
+        rtol=1e-3,
+        err_msg="P element (real part) should match cold",
+    )
 
-    # these fail, unclear why!
-    # np.testing.assert_allclose(eps_wr[0, 1], eps_cold[0, 1], rtol=0, atol=1e-8)
-    # np.testing.assert_allclose(eps_wr[0, 0] - 1, eps_cold[0, 0] - 1, rtol=0, atol=1e-8)
-    # np.testing.assert_allclose(1 - eps_wr[2, 2], 1 - eps_cold[2, 2], rtol=0, atol=1e-8)
+    # Anti-Hermitian part (absorption) must vanish far from resonance
+    for i in range(3):
+        np.testing.assert_allclose(
+            eps_wr[i, i].imag,
+            0,
+            atol=1e-4,
+            err_msg=f"ε_warm[{i},{i}].imag should be ~0",
+        )
+
+    # Both use KO convention: off-diagonal D must converge to the same value
+    np.testing.assert_allclose(
+        float(eps_wr[0, 1].imag),
+        float(eps_cold[0, 1].imag),
+        rtol=1e-3,
+        err_msg="ε[0,1].imag should match cold D value",
+    )
+    assert float(eps_wr[0, 1].imag) * float(eps_cold[0, 1].imag) > 0, (
+        "ε_warm[0,1].imag and ε_cold[0,1].imag must have the same sign "
+        "(both use KO electron-sign convention)"
+    )
+
+
+@pytest.mark.parametrize("mode", ["X", "O"])
+def test_dispersion_invariant_under_d_sign_flip(mode):
+    """The dispersion relation det(Λ) = 0 is invariant under D → −D.
+
+    D enters the dispersion tensor only through off-diagonal imaginary elements.
+    The determinant of the dispersion tensor depends on D² (never on D linearly),
+    so flipping the sign of D cannot change the zeros N².  This is a general
+    mathematical property of the Stix-form dispersion tensor.
+    """
+    frequency = 200e9
+    plasma_frequency = 50e9
+    cyclotron_frequency = 400e9  # Y = 2, far from resonance
+    Y = cyclotron_frequency / frequency
+    X = (plasma_frequency / frequency) ** 2
+    sin2theta = 0.7
+
+    eps = cold_dielectric_tensor(
+        frequency=frequency,
+        plasma_frequency=plasma_frequency,
+        cyclotron_frequency=cyclotron_frequency,
+    )
+    # Build a tensor with D flipped
+    eps_d_flipped = jnp.array(
+        [
+            [eps[0, 0], -eps[0, 1], eps[0, 2]],
+            [-eps[1, 0], eps[1, 1], eps[1, 2]],
+            [eps[2, 0], eps[2, 1], eps[2, 2]],
+        ]
+    )
+
+    n2 = float(_dispersion_appleton_hartee(X=X, Y=Y, sin2theta=sin2theta, mode=mode))
+    n_perp = jnp.sqrt(n2 * sin2theta)
+    n_para = jnp.sqrt(n2 * (1 - sin2theta))
+
+    det_orig = float(jnp.linalg.det(dispersion_tensor_stix(n_perp, n_para, eps)).real)
+    det_flip = float(
+        jnp.linalg.det(dispersion_tensor_stix(n_perp, n_para, eps_d_flipped)).real
+    )
+
+    # Both must be zero at the same N²
+    np.testing.assert_allclose(
+        det_orig, 0, atol=1e-14, err_msg="original tensor must satisfy dispersion"
+    )
+    np.testing.assert_allclose(
+        det_flip, 0, atol=1e-14, err_msg="D-flipped tensor must satisfy same dispersion"
+    )
 
 
 @pytest.mark.parametrize("mode", ["X", "O"])

--- a/tests/physics/dielectric_tensor_test.py
+++ b/tests/physics/dielectric_tensor_test.py
@@ -223,12 +223,12 @@ def test_dispersion_invariant_under_d_sign_flip(mode):
         jnp.linalg.det(dispersion_tensor_stix(n_perp, n_para, eps_d_flipped)).real
     )
 
-    # Both must be zero at the same N²
+    # Flipping D must not change the dispersion relation
     np.testing.assert_allclose(
-        det_orig, 0, atol=1e-14, err_msg="original tensor must satisfy dispersion"
-    )
-    np.testing.assert_allclose(
-        det_flip, 0, atol=1e-14, err_msg="D-flipped tensor must satisfy same dispersion"
+        det_flip,
+        det_orig,
+        atol=1e-14,
+        err_msg="D-flipped tensor must satisfy same dispersion",
     )
 
 


### PR DESCRIPTION
Multiple improvements and fixes implemented as part of the absorption validation.

# AI generated summary

This pull request introduces significant improvements and generalizations to the absorption coefficient and related physics calculations in the raytrax codebase. The most important changes are the generalization of cyclotron harmonic handling (now supporting arbitrary harmonics), improved numerical stability and accuracy in resonance integration, and the introduction of a cold-plasma power flux vector to avoid singularities near harmonics. Additionally, the documentation and code comments have been updated for clarity, and sign conventions in dielectric tensor calculations have been made explicit and consistent.

**Generalization to Arbitrary Cyclotron Harmonics:**
- The absorption coefficient and related functions now accept a `max_harmonic` parameter, allowing calculations to include higher cyclotron harmonics, not just the first and second. This parameter propagates through the API, physics, and tracer settings, and is used consistently in the harmonic summations and tensor expansions. [[1]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fR26) [[2]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fR38-R41) [[3]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fR76) [[4]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fR108-R119) [[5]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fR145) [[6]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fR174) [[7]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fR206-R212) [[8]](diffhunk://#diff-e7741565d3c5b2b4311ee81b0fd8e7bad2c0e63c3b28fec9cfa95d9393adebceR16) [[9]](diffhunk://#diff-446c7f4bd01d9e4a930ebc0c0a7f62c202d7bcf3b4124950cf455d614d7c378eL143-R145)

**Numerical Stability and Resonance Integration Improvements:**
- The resonance integral computation has been improved by refining the integration bounds, using a wider cutoff to better capture the Maxwellian distribution's bulk, and clamping the window to avoid divergences near the light line. Explanatory comments and logic have been updated for clarity and correctness. [[1]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fL265-R281) [[2]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fL280-R311) [[3]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fL300-R322)

**Cold-Plasma Power Flux Vector and Avoidance of Singularities:**
- A new function `cold_power_flux_vector_stix` is introduced for evaluating the power flux vector using the cold dielectric tensor, avoiding singularities in the warm tensor near electron cyclotron harmonics. The absorption calculation now uses this cold-plasma version for the denominator, with detailed documentation added to both implementation and usage. [[1]](diffhunk://#diff-138e763d5cb748868687f958a9af4762309db8dca1d3772071e4fc181c79af83R149-R242) [[2]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fL116-L122)

**Dielectric Tensor Sign Convention Consistency:**
- The sign convention for the cold and weakly-relativistic dielectric tensors is now explicitly documented and implemented according to the Krivenski-Orefice (KO) convention. This ensures consistency between the cold and warm tensor calculations, and clarifies the physical meaning of the tensor components. [[1]](diffhunk://#diff-7deb7664772e225e7b111865b0a2c2e3f2f6f7606493d98b5adae5ceb25ab359R21-R42) [[2]](diffhunk://#diff-7deb7664772e225e7b111865b0a2c2e3f2f6f7606493d98b5adae5ceb25ab359L59-R68)

**Documentation and Code Clarity:**
- Extensive updates to docstrings, comments, and documentation files clarify the physical meaning, mathematical formulas, and implementation details, including the rationale for the power flux vector calculation and the use of the KO tensor. [[1]](diffhunk://#diff-9a66bd5f9c8d6a10447cd56aca9c90a85a61e49281d46a228ff51ff0155d76bcL68-R81) [[2]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fR38-R41) [[3]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fR87-R89) [[4]](diffhunk://#diff-95bf54a9637ea5ea73da0b1e4eafd57edf34c644063ad0167e08e5f3cca4c18fR206-R212) [[5]](diffhunk://#diff-7deb7664772e225e7b111865b0a2c2e3f2f6f7606493d98b5adae5ceb25ab359R21-R42)

These changes collectively enhance the flexibility, reliability, and clarity of the codebase for modeling electron cyclotron absorption and related wave-plasma interactions.