### PR TITLE
Temporarily pin interpax<0.3.14 to fix CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "jaxtyping",
   "numpy",
   "scipy",
-  "interpax",
+  "interpax<0.3.14",
   "diffrax>=0.7.1",
   "beartype",
   "vmecpp",


### PR DESCRIPTION
## Summary

- interpax 0.3.14 (released 2026-04-18) introduced `jnp.array(0)` as default argument values in `safediv` in `_fd_derivs.py`. Python evaluates default arguments at function definition time, so this runs at `import interpax`.
- interpax 0.3.14 also widened its JAX constraint from `<0.8` to `<0.11`, which allows JAX 0.10.0 (released 2026-04-16) to be installed.
- With JAX 0.10.0, `jnp.array(0)` at import time triggers `get_default_device()` → `xb.local_devices()` → `backends()`, initializing the XLA backend as a side effect of a plain `import interpax`.
- This broke `tests/import_test.py::test_import_does_not_initialize_jax_backend`.

An issue/PR will be filed upstream against interpax. This pin is temporary until that is resolved.

## Test plan

- [ ] CI passes with this pin (interpax 0.3.13 installs, JAX stays <0.8, backend not initialized on import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)