### PR TITLE
_bin_power_deposition: prevent undershoot, pass full array

### DIFF
--- a/src/raytrax/api.py
+++ b/src/raytrax/api.py
@@ -27,6 +27,18 @@ from .types import (
 _N_INTERP = 2000  # dense arc-length samples used for smooth radial binning
 
 
+def _next_power_of_two(n: int) -> int:
+    """Return the smallest power of two >= n (minimum 4).
+
+    Used to bucket the valid trajectory length to a small set of fixed sizes,
+    limiting XLA recompilation count to O(log(max_steps)) ≈ 12 while keeping
+    the number of spline knots close to the actual trajectory length.
+    diffrax fills arc_length[n:] with inf, so arc_length[:bucket] has exactly
+    the right inf-padding structure that _bin_power_deposition already handles.
+    """
+    return max(4, 1 << max(0, (n - 1).bit_length()))
+
+
 def _bin_power_deposition(
     rho_grid: jt.Float[jax.Array, " nrho"],
     dvolume_drho: jt.Float[jax.Array, " nrho"],
@@ -255,9 +267,9 @@ def trace(
     power_binned = _bin_power_deposition(
         magnetic_configuration.rho_1d,
         magnetic_configuration.dvolume_drho,
-        result.arc_length,  # full padded array; _bin_power_deposition sanitizes inf
-        result.normalized_effective_radius,
-        result.ode_state[:, 6],
+        result.arc_length[: _next_power_of_two(n)],
+        result.normalized_effective_radius[: _next_power_of_two(n)],
+        result.ode_state[: _next_power_of_two(n), 6],
     )
 
     tau_final = beam_profile.optical_depth[-1]

--- a/src/raytrax/api.py
+++ b/src/raytrax/api.py
@@ -68,10 +68,12 @@ def _bin_power_deposition(
     # Any finite fill for rho at padded slots — those slots are never queried.
     rho_trajectory = jnp.where(jnp.isfinite(rho_trajectory), rho_trajectory, 0.0)
 
-    # --- 2. Dense cubic interpolation along arc length ---------------------
+    # --- 2. Dense interpolation along arc length ---------------------
+    # tau uses linear (not cubic) to preserve monotonicity: cubic undershoots
+    # below zero, making exp(-tau) > 1 and inflating the total binned power.
     s_fine = jnp.linspace(arc_length[0], s_max, _N_INTERP)
     rho_fine = interpax.interp1d(s_fine, arc_length, rho_trajectory, method="cubic")
-    tau_fine = interpax.interp1d(s_fine, arc_length, optical_depth, method="cubic")
+    tau_fine = interpax.interp1d(s_fine, arc_length, optical_depth, method="linear")
 
     # --- 3. Exact overlap-based binning on dense samples -------------------
     # dP_i = exp(-τ_i) − exp(-τ_{i+1}), clamped to ≥ 0.
@@ -253,9 +255,9 @@ def trace(
     power_binned = _bin_power_deposition(
         magnetic_configuration.rho_1d,
         magnetic_configuration.dvolume_drho,
-        result.arc_length[:n],
-        result.normalized_effective_radius[:n],
-        result.ode_state[:n, 6],
+        result.arc_length,  # full padded array; _bin_power_deposition sanitizes inf
+        result.normalized_effective_radius,
+        result.ode_state[:, 6],
     )
 
     tau_final = beam_profile.optical_depth[-1]

--- a/src/raytrax/api.py
+++ b/src/raytrax/api.py
@@ -88,8 +88,11 @@ def _bin_power_deposition(
         s_max_safe * (2.0 + jnp.arange(arc_length.shape[0])),
     )
 
-    # Any finite fill for rho at padded slots — those slots are never queried.
-    rho_trajectory = jnp.where(jnp.isfinite(rho_trajectory), rho_trajectory, 0.0)
+    # Pad rho with the last valid value, not 0: using 0 would pull the cubic
+    # spline's boundary derivative at s_max toward zero, distorting the profile.
+    n_valid_rho = jnp.sum(jnp.isfinite(rho_trajectory), dtype=jnp.int32)
+    rho_last = rho_trajectory[jnp.maximum(n_valid_rho - 1, 0)]
+    rho_trajectory = jnp.where(jnp.isfinite(rho_trajectory), rho_trajectory, rho_last)
 
     # --- 2. Dense interpolation along arc length ---------------------
     # tau uses linear (not cubic) to preserve monotonicity: cubic undershoots
@@ -277,8 +280,7 @@ def trace(
         linear_power_density=result.linear_power_density[:n] * beam.power,
     )
 
-    # Clamp to the actual buffer size so that a full-length trace (n == buffer
-    # size) does not produce n_bucket > buffer_size → unique shape defeating bucketing.
+    # Clamp: _next_power_of_two(n) can exceed the buffer length (e.g. 4097→8192).
     n_bucket = min(_next_power_of_two(n), result.arc_length.shape[0])
     power_binned = _bin_power_deposition(
         magnetic_configuration.rho_1d,

--- a/src/raytrax/api.py
+++ b/src/raytrax/api.py
@@ -53,9 +53,10 @@ def _bin_power_deposition(
     directly we:
 
     1. Sanitize inf padding (diffrax fills unused sol.ys slots with inf).
-    2. Linearly interpolate rho(s) and τ(s) to _N_INTERP uniformly-spaced
+    2. Interpolate rho(s) (cubic) and τ(s) (linear) to _N_INTERP uniformly-spaced
        arc-length samples — no bandwidth choice needed, smoothness follows
-       from density.
+       from density. τ uses linear to preserve monotonicity; rho uses cubic
+       for smooth deposition profiles.
     3. Use exact overlap-based binning on the dense samples.
     """
     # --- 1. Sanitize inf padding -------------------------------------------
@@ -67,6 +68,16 @@ def _bin_power_deposition(
     optical_depth = jnp.where(jnp.isfinite(optical_depth), optical_depth, tau_final)
 
     s_max = jnp.max(jnp.where(jnp.isfinite(arc_length), arc_length, 0.0))
+
+    # Degenerate case: only the initial point is present (n_valid=1, s_max=0).
+    # Padding formula s_max*(2+arange) would produce duplicate zero knots,
+    # corrupting the spline.  Use s_max_safe=1 as a stand-in so all arithmetic
+    # stays finite; the result is masked to zero at the end via jnp.where so
+    # no spurious deposition is ever returned.  Using jnp.where (not a Python
+    # `if`) keeps the function JIT-traceable.
+    is_degenerate = s_max == 0
+    s_max_safe = jnp.where(is_degenerate, 1.0, s_max)
+
     # Push padded entries well beyond s_max with *distinct* monotone values.
     # All-equal padding (s_max + 1) creates duplicate cubic knots that corrupt
     # the spline within [0, s_max].  Spacing by s_max per slot pushes each
@@ -74,7 +85,7 @@ def _bin_power_deposition(
     arc_length = jnp.where(
         jnp.isfinite(arc_length),
         arc_length,
-        s_max * (2.0 + jnp.arange(arc_length.shape[0])),
+        s_max_safe * (2.0 + jnp.arange(arc_length.shape[0])),
     )
 
     # Any finite fill for rho at padded slots — those slots are never queried.
@@ -83,7 +94,7 @@ def _bin_power_deposition(
     # --- 2. Dense interpolation along arc length ---------------------
     # tau uses linear (not cubic) to preserve monotonicity: cubic undershoots
     # below zero, making exp(-tau) > 1 and inflating the total binned power.
-    s_fine = jnp.linspace(arc_length[0], s_max, _N_INTERP)
+    s_fine = jnp.linspace(arc_length[0], s_max_safe, _N_INTERP)
     rho_fine = interpax.interp1d(s_fine, arc_length, rho_trajectory, method="cubic")
     tau_fine = interpax.interp1d(s_fine, arc_length, optical_depth, method="linear")
 
@@ -123,7 +134,9 @@ def _bin_power_deposition(
     power_per_bin = dP @ weights  # (nrho,)
 
     dV = dvolume_drho * (bin_hi - bin_lo)
-    return power_per_bin / jnp.maximum(dV, 1e-30)
+    result = power_per_bin / jnp.maximum(dV, 1e-30)
+    # Mask to zero for the degenerate single-point case (s_max=0).
+    return jnp.where(is_degenerate, jnp.zeros_like(result), result)
 
 
 def _deposition_stats(
@@ -264,12 +277,15 @@ def trace(
         linear_power_density=result.linear_power_density[:n] * beam.power,
     )
 
+    # Clamp to the actual buffer size so that a full-length trace (n == buffer
+    # size) does not produce n_bucket > buffer_size → unique shape defeating bucketing.
+    n_bucket = min(_next_power_of_two(n), result.arc_length.shape[0])
     power_binned = _bin_power_deposition(
         magnetic_configuration.rho_1d,
         magnetic_configuration.dvolume_drho,
-        result.arc_length[: _next_power_of_two(n)],
-        result.normalized_effective_radius[: _next_power_of_two(n)],
-        result.ode_state[: _next_power_of_two(n), 6],
+        result.arc_length[:n_bucket],
+        result.normalized_effective_radius[:n_bucket],
+        result.ode_state[:n_bucket, 6],
     )
 
     tau_final = beam_profile.optical_depth[-1]

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -247,13 +247,14 @@ def test_bin_power_with_padded_zeros():
 
 
 def test_bin_power_full_padded_arrays_match_trimmed():
-    """Full padded arrays (all three inf) give same result as trimmed arrays.
+    """inf-padded tail in all three arrays does not change the deposited power.
 
-    This test mirrors exactly what trace(trim=True) now does: it passes the
-    full (max_steps+1)-length arrays to _bin_power_deposition without slicing
-    to [:n]. diffrax fills arc_length, ode_state (→ optical_depth), and
-    normalized_effective_radius with inf for every unused slot, so all three
-    arrays contain inf in the padded region.
+    This regression test covers the sanitization path in _bin_power_deposition.
+    trace(trim=True) passes power-of-2 bucketed slices (not the full max_steps+1
+    buffer), so the padded region is small (at most bucket-n entries of inf);
+    this test exercises the same sanitization with a larger pad to confirm
+    robustness. diffrax fills arc_length, ode_state (→ optical_depth), and
+    normalized_effective_radius with inf for every unused slot.
     """
     rho_grid = jnp.linspace(0.0, 1.0, 20)
     dvolume_drho = jnp.ones(20)
@@ -293,14 +294,22 @@ def test_bin_power_full_padded_arrays_match_trimmed():
 
 
 def test_next_power_of_two():
-    """_next_power_of_two returns a small set of fixed sizes to cap XLA recompilations."""
+    """_next_power_of_two returns a small set of fixed sizes to cap XLA recompilations.
+
+    The function itself may return a value larger than the actual buffer length
+    (e.g. 4097 → 8192); the caller is responsible for clamping to the buffer
+    size so that full-length traces don't produce a unique shape.
+    """
     assert _next_power_of_two(1) == 4
     assert _next_power_of_two(4) == 4
     assert _next_power_of_two(5) == 8
     assert _next_power_of_two(8) == 8
     assert _next_power_of_two(9) == 16
     assert _next_power_of_two(4096) == 4096
+    # 4097 exceeds the last power-of-two bucket; the caller clamps to buffer length.
     assert _next_power_of_two(4097) == 8192
+    # Verify the caller-side clamp: min(_next_power_of_two(4097), 4097) == 4097
+    assert min(_next_power_of_two(4097), 4097) == 4097
 
 
 def test_bin_power_bucketed_slice_matches_trimmed():
@@ -355,3 +364,29 @@ def test_bin_power_bucketed_slice_matches_trimmed():
     total_trimmed = float(jnp.sum(result_trimmed * dV))
     # Bucketed slice has only 3 extra inf knots → negligible spline perturbation.
     np.testing.assert_allclose(total_bucketed, total_trimmed, rtol=0.01)
+
+
+def test_bin_power_deposition_single_point_returns_zeros():
+    """n_valid=1 (s_max=0) returns an all-zero deposition profile without crashing.
+
+    When the ODE solver terminates immediately (e.g., beam starts outside the
+    plasma), arc_length = [0.0] and s_max = 0.  The padding formula
+    s_max*(2+arange) would collapse all padded knots to 0, producing duplicate
+    spline knots and corrupting the interpolation.  _bin_power_deposition must
+    detect s_max==0 and return zeros instead of attempting the spline.
+    """
+    rho_grid = jnp.linspace(0.0, 1.0, 20)
+    dvolume_drho = jnp.ones(20)
+
+    # Single valid point (what diffrax produces for an immediately-terminated trace)
+    # followed by the inf padding that _next_power_of_two(1)==4 would expose.
+    arc_length = jnp.array([0.0, jnp.inf, jnp.inf, jnp.inf])
+    rho_trajectory = jnp.array([0.5, jnp.inf, jnp.inf, jnp.inf])
+    optical_depth = jnp.array([0.0, jnp.inf, jnp.inf, jnp.inf])
+
+    result = _bin_power_deposition(
+        rho_grid, dvolume_drho, arc_length, rho_trajectory, optical_depth
+    )
+
+    assert result.shape == rho_grid.shape
+    assert jnp.all(result == 0.0), "Single-point trace must return zero deposition"

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -244,3 +244,49 @@ def test_bin_power_with_padded_zeros():
     # A global cubic spline has different boundary conditions when padded
     # points are present, so perfect agreement is not achievable; 5% is fine.
     np.testing.assert_allclose(result_padded, result_trimmed, rtol=0.05)
+
+
+def test_bin_power_full_padded_arrays_match_trimmed():
+    """Full padded arrays (all three inf) give same result as trimmed arrays.
+
+    This test mirrors exactly what trace(trim=True) now does: it passes the
+    full (max_steps+1)-length arrays to _bin_power_deposition without slicing
+    to [:n]. diffrax fills arc_length, ode_state (→ optical_depth), and
+    normalized_effective_radius with inf for every unused slot, so all three
+    arrays contain inf in the padded region.
+    """
+    rho_grid = jnp.linspace(0.0, 1.0, 20)
+    dvolume_drho = jnp.ones(20)
+
+    n_valid = 8
+    n_pad = 42  # simulate a large fixed-size buffer with many unused slots
+
+    rho_valid = jnp.linspace(0.9, 0.2, n_valid)
+    tau_valid = jnp.linspace(0.0, 2.5, n_valid)
+    s_valid = jnp.linspace(0.0, 0.7, n_valid)
+
+    # All three arrays are inf in the padded region — exactly as diffrax produces.
+    rho_trajectory = jnp.concatenate([rho_valid, jnp.full(n_pad, jnp.inf)])
+    optical_depth = jnp.concatenate([tau_valid, jnp.full(n_pad, jnp.inf)])
+    arc_length = jnp.concatenate([s_valid, jnp.full(n_pad, jnp.inf)])
+
+    result_full = _bin_power_deposition(
+        rho_grid, dvolume_drho, arc_length, rho_trajectory, optical_depth
+    )
+    result_trimmed = _bin_power_deposition(
+        rho_grid, dvolume_drho, s_valid, rho_valid, tau_valid
+    )
+
+    assert result_full.shape == rho_grid.shape
+    assert jnp.all(jnp.isfinite(result_full)), (
+        "inf in rho_trajectory (padded slots) must be sanitized before binning"
+    )
+
+    # Power conservation: total deposited power is the same regardless of padding.
+    edges = jnp.concatenate(
+        [rho_grid[:1], 0.5 * (rho_grid[:-1] + rho_grid[1:]), rho_grid[-1:]]
+    )
+    dV = dvolume_drho * jnp.diff(edges)
+    total_full = float(jnp.sum(result_full * dV))
+    total_trimmed = float(jnp.sum(result_trimmed * dV))
+    np.testing.assert_allclose(total_full, total_trimmed, rtol=0.02)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -393,13 +393,10 @@ def test_bin_power_deposition_single_point_returns_zeros():
 
 
 def test_bin_power_large_bucket_profile_matches_trimmed():
-    """Large bucket (2049 → 4096) preserves both total power and profile shape.
+    """n=2049 → bucket=4096 (2047 padding slots) preserves total power and profile shape.
 
-    This is the highest-risk regime: 2047 inf-padding slots become rho-padded
-    knots.  If rho padding uses 0 instead of the last valid rho value, the
-    cubic spline's boundary derivative at s_max is pulled toward zero, creating
-    a downward artifact in the deposition profile near the trajectory end.
-    Tests both total power conservation and per-bin profile shape.
+    Catches rho-padding bugs: using rho=0 for padding knots distorts the cubic
+    spline's boundary derivative at s_max, creating artifacts near the trajectory end.
     """
     rho_grid = jnp.linspace(0.0, 1.0, 20)
     dvolume_drho = jnp.ones(20)
@@ -408,8 +405,7 @@ def test_bin_power_large_bucket_profile_matches_trimmed():
     n_bucket = _next_power_of_two(n_valid)
     assert n_bucket == 4096
 
-    # Beam traversal that stops well inside the plasma (last rho ≠ 0),
-    # so zero-padding of rho would distort the boundary derivative.
+    # Last rho is 0.45 (not 0), so zero-padding would distort the boundary derivative.
     rho_valid = jnp.linspace(0.9, 0.45, n_valid)
     tau_valid = jnp.linspace(0.0, 3.5, n_valid)
     s_valid = jnp.linspace(0.0, 2.5, n_valid)
@@ -436,8 +432,6 @@ def test_bin_power_large_bucket_profile_matches_trimmed():
     total_bucketed = float(jnp.sum(result_bucketed * dV))
     total_trimmed = float(jnp.sum(result_trimmed * dV))
 
-    # Total power must be conserved.
+    # Total power and per-bin profile must match (latter catches spline boundary artifacts).
     np.testing.assert_allclose(total_bucketed, total_trimmed, rtol=0.01)
-    # Per-bin profile shape must also match — this catches cubic spline boundary
-    # artifacts from zero-padded rho knots distorting deposition near s_max.
     np.testing.assert_allclose(result_bucketed, result_trimmed, rtol=0.05, atol=1e-6)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3,7 +3,7 @@
 import jax.numpy as jnp
 import numpy as np
 
-from raytrax.api import _bin_power_deposition, trace
+from raytrax.api import _bin_power_deposition, _next_power_of_two, trace
 from raytrax.equilibrium.interpolate import MagneticConfiguration
 from raytrax.types import Beam, RadialProfiles, TracerSettings
 
@@ -290,3 +290,68 @@ def test_bin_power_full_padded_arrays_match_trimmed():
     total_full = float(jnp.sum(result_full * dV))
     total_trimmed = float(jnp.sum(result_trimmed * dV))
     np.testing.assert_allclose(total_full, total_trimmed, rtol=0.02)
+
+
+def test_next_power_of_two():
+    """_next_power_of_two returns a small set of fixed sizes to cap XLA recompilations."""
+    assert _next_power_of_two(1) == 4
+    assert _next_power_of_two(4) == 4
+    assert _next_power_of_two(5) == 8
+    assert _next_power_of_two(8) == 8
+    assert _next_power_of_two(9) == 16
+    assert _next_power_of_two(4096) == 4096
+    assert _next_power_of_two(4097) == 8192
+
+
+def test_bin_power_bucketed_slice_matches_trimmed():
+    """Power-of-2 bucketed slice gives same deposition as exact trimmed slice.
+
+    trace(trim=True) now passes result.arc_length[:_next_power_of_two(n)] instead of
+    either result.arc_length[:n] (variable shape → recompilation) or result.arc_length
+    (full 4097 knots → spline perturbation). The bucketed slice has at most
+    bucket - n extra inf knots, which the sanitization step pushes well beyond s_max.
+    """
+    rho_grid = jnp.linspace(0.0, 1.0, 20)
+    dvolume_drho = jnp.ones(20)
+
+    n_valid = 13  # not a power of two → bucket = 16
+    n_bucket = _next_power_of_two(n_valid)  # 16
+    n_total = 64  # simulate a larger fixed buffer
+
+    assert n_bucket == 16
+
+    rho_valid = jnp.linspace(0.85, 0.15, n_valid)
+    tau_valid = jnp.linspace(0.0, 3.0, n_valid)
+    s_valid = jnp.linspace(0.0, 1.2, n_valid)
+
+    # Build a full diffrax-style buffer: valid entries then inf padding.
+    rho_buf = jnp.concatenate([rho_valid, jnp.full(n_total - n_valid, jnp.inf)])
+    tau_buf = jnp.concatenate([tau_valid, jnp.full(n_total - n_valid, jnp.inf)])
+    s_buf = jnp.concatenate([s_valid, jnp.full(n_total - n_valid, jnp.inf)])
+
+    result_bucketed = _bin_power_deposition(
+        rho_grid,
+        dvolume_drho,
+        s_buf[:n_bucket],
+        rho_buf[:n_bucket],
+        tau_buf[:n_bucket],
+    )
+    result_trimmed = _bin_power_deposition(
+        rho_grid,
+        dvolume_drho,
+        s_valid,
+        rho_valid,
+        tau_valid,
+    )
+
+    assert result_bucketed.shape == rho_grid.shape
+    assert jnp.all(jnp.isfinite(result_bucketed))
+
+    edges = jnp.concatenate(
+        [rho_grid[:1], 0.5 * (rho_grid[:-1] + rho_grid[1:]), rho_grid[-1:]]
+    )
+    dV = dvolume_drho * jnp.diff(edges)
+    total_bucketed = float(jnp.sum(result_bucketed * dV))
+    total_trimmed = float(jnp.sum(result_trimmed * dV))
+    # Bucketed slice has only 3 extra inf knots → negligible spline perturbation.
+    np.testing.assert_allclose(total_bucketed, total_trimmed, rtol=0.01)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -390,3 +390,54 @@ def test_bin_power_deposition_single_point_returns_zeros():
 
     assert result.shape == rho_grid.shape
     assert jnp.all(result == 0.0), "Single-point trace must return zero deposition"
+
+
+def test_bin_power_large_bucket_profile_matches_trimmed():
+    """Large bucket (2049 → 4096) preserves both total power and profile shape.
+
+    This is the highest-risk regime: 2047 inf-padding slots become rho-padded
+    knots.  If rho padding uses 0 instead of the last valid rho value, the
+    cubic spline's boundary derivative at s_max is pulled toward zero, creating
+    a downward artifact in the deposition profile near the trajectory end.
+    Tests both total power conservation and per-bin profile shape.
+    """
+    rho_grid = jnp.linspace(0.0, 1.0, 20)
+    dvolume_drho = jnp.ones(20)
+
+    n_valid = 2049  # just above a bucket boundary → bucket = 4096
+    n_bucket = _next_power_of_two(n_valid)
+    assert n_bucket == 4096
+
+    # Beam traversal that stops well inside the plasma (last rho ≠ 0),
+    # so zero-padding of rho would distort the boundary derivative.
+    rho_valid = jnp.linspace(0.9, 0.45, n_valid)
+    tau_valid = jnp.linspace(0.0, 3.5, n_valid)
+    s_valid = jnp.linspace(0.0, 2.5, n_valid)
+
+    n_pad = n_bucket - n_valid  # 2047
+    rho_buf = jnp.concatenate([rho_valid, jnp.full(n_pad, jnp.inf)])
+    tau_buf = jnp.concatenate([tau_valid, jnp.full(n_pad, jnp.inf)])
+    s_buf = jnp.concatenate([s_valid, jnp.full(n_pad, jnp.inf)])
+
+    result_bucketed = _bin_power_deposition(
+        rho_grid, dvolume_drho, s_buf, rho_buf, tau_buf
+    )
+    result_trimmed = _bin_power_deposition(
+        rho_grid, dvolume_drho, s_valid, rho_valid, tau_valid
+    )
+
+    assert result_bucketed.shape == rho_grid.shape
+    assert jnp.all(jnp.isfinite(result_bucketed))
+
+    edges = jnp.concatenate(
+        [rho_grid[:1], 0.5 * (rho_grid[:-1] + rho_grid[1:]), rho_grid[-1:]]
+    )
+    dV = dvolume_drho * jnp.diff(edges)
+    total_bucketed = float(jnp.sum(result_bucketed * dV))
+    total_trimmed = float(jnp.sum(result_trimmed * dV))
+
+    # Total power must be conserved.
+    np.testing.assert_allclose(total_bucketed, total_trimmed, rtol=0.01)
+    # Per-bin profile shape must also match — this catches cubic spline boundary
+    # artifacts from zero-padded rho knots distorting deposition near s_max.
+    np.testing.assert_allclose(result_bucketed, result_trimmed, rtol=0.05, atol=1e-6)

--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -5,15 +5,13 @@ https://github.com/patrick-kidger/optimistix/pull/186 so this test both
 guards against regressions in our dependencies and makes sure we don't
 accidentally introduce this problem ourselves."""
 
+import os
 import subprocess
 import sys
 
 
 def test_import_does_not_initialize_jax_backend():
     script = """
-import jax
-jax.config.update('jax_enable_x64', True)
-
 import raytrax  # noqa: F401
 
 import jax._src.xla_bridge as xb
@@ -21,11 +19,13 @@ initialized = bool(xb._backends)
 if initialized:
     raise SystemExit(f"JAX backend was initialized on import: {list(xb._backends.keys())}")
 """
+    env = {**os.environ, "JAX_ENABLE_X64": "1"}
     result = subprocess.run(
         [sys.executable, "-c", script],
         capture_output=True,
         timeout=120,
         text=True,
+        env=env,
     )
     assert result.returncode == 0, (
         f"JAX backend was initialized during `import raytrax`.\n"

--- a/zensical.toml
+++ b/zensical.toml
@@ -40,7 +40,6 @@ extra_javascript = [
 ]
 
 [project.theme]
-name = "zensical"
 logo = "assets/proxima.svg"
 favicon = "assets/proxima.svg"
 features = [


### PR DESCRIPTION
This should help fix issues with slow traces in a parameter scan.